### PR TITLE
Allow for Empty Error Strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: bash
 
 before_script:
-    - sudo sh -c "$(curl -L https://raw.github.com/rylnd/shpec/master/install.sh)"
+- sudo sh -c "$(curl -L https://raw.github.com/rylnd/shpec/master/install.sh)"
 
 script:
-    - bash test.sh
+- bash test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: bash
+
+before_script:
+    - sudo sh -c "$(curl -L https://raw.github.com/rylnd/shpec/master/install.sh)"
+
+script:
+    - bash test.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # shtub
 Bash command stubbing
 
+[![travis]](https://travis-ci.org/Runnable/shtub)
+
 ## Overview
 shtub is a bash testing utility that allows for the creation of command stubs
 in a bash environment. A stub acts as a "faux" command which override the

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # shtub
 Bash command stubbing
 
-[![travis]](https://travis-ci.org/Runnable/shtub)
+[![Build Status](https://travis-ci.org/Runnable/shtub.svg?branch=master)](https://travis-ci.org/Runnable/shtub)
 
 ## Overview
 shtub is a bash testing utility that allows for the creation of command stubs

--- a/shtub.sh
+++ b/shtub.sh
@@ -223,16 +223,28 @@ _stub::methods::returns() {
 # Sets a stub to error by printing the given string to stderr and returning the
 # given status code.
 # @param $1 name Name of the command to stub
-# @param $2 output Output to send to stderr
+# @param $2 [output] Output to send to stderr
 # @param $3 [code=1] Status code to return
 _stub::methods::errors() {
   local name="$1"
-  local output="${@:2:$#-2}"
-  local code="${@:$#}"
+  local output
+  local code
 
-  if ! [ "$code" -eq "$code" ] 2> /dev/null; then
-    output="$output $code"
+  # Handle the optional parameters
+  if [ $# -lt 2 ]; then
+    output="$2"
     code=1
+    if [ "$output" -eq "$output" ] 2> /dev/null; then
+      code="$output"
+      output=''
+    fi
+  else
+    output="${@:2:$#-2}"
+    code="${@:$#}"
+    if ! [ "$code" -eq "$code" ] 2> /dev/null; then
+      output="$output $code"
+      code=1
+    fi
   fi
 
   _stub::data::set "$name" 'default_command' ''

--- a/test/methods.sh
+++ b/test/methods.sh
@@ -39,12 +39,44 @@ describe '_stub::methods'
   end # returns
 
   describe 'errors'
+    # before
+      stub 'bad'
+    # end
+
     it 'should cause the stub to error with the given output'
-      stub 'wonky'
-      wonky::errors 'noo'
-      assert equal $(wonky 2>&1) 'noo'
-      wonky::restore
+      local message='noooo'
+      bad::errors "$message"
+      assert equal "$(bad 2>&1)" "$message"
     end
+
+    it 'should use the given error code'
+      local code=122
+      bad::errors 'nope' "$code"
+      bad &> /dev/null
+      assert equal "$?" "$code"
+    end
+
+    it 'should allow for empty stderr output'
+      bad::errors
+      assert equal "$(bad 2>&1)" ''
+    end
+
+    it 'should return an error code with empty output'
+      bad::errors
+      bad &> /dev/null
+      assert equal "$?" '1'
+    end
+
+    it 'should allow for empty output with a status code'
+      local code=111
+      bad::errors "$code"
+      bad &> /dev/null
+      assert equal "$?" "$code"
+    end
+
+    # after
+      bad::restore
+    # end
   end # errors
 
   describe 'exec'


### PR DESCRIPTION
This modifies the library to allow users to set a stub to error with empty output to `stderr`.
