### PR TITLE
Use a File Store for Stub Variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+.stubdata

--- a/shtub.sh
+++ b/shtub.sh
@@ -145,6 +145,7 @@ _stub::assert() {
   if [ -n "$(type -t assert)" ] && [ "$(type -t assert)" = 'function' ]; then
     assert equal "$last_code" '0'
   fi
+  return $last_code
 }
 
 # Executes a stubbed command.

--- a/shtub.sh
+++ b/shtub.sh
@@ -36,7 +36,7 @@ _stub_env=$(which env)
 # Gets the prefix for data variables associated with a stub of the given name
 # @param $1 name Name of the stub.
 _stub::data::prefix() {
-  local name="$1"
+  local name=$($_stub_echo "$1" | $_stub_sed 's/:/_/g')
   $_stub_echo "_stub_data_${name}"
 }
 

--- a/shtub.sh
+++ b/shtub.sh
@@ -28,6 +28,8 @@ _stub_grep="$(which grep)"
 _stub_sed="$(which sed)"
 _stub_awk="$(which awk)"
 _stub_env=$(which env)
+_stub_cat=$(which cat)
+_stub_cut=$(which cut)
 
 ################################################################################
 # Core Methods
@@ -35,9 +37,15 @@ _stub_env=$(which env)
 
 # Gets the prefix for data variables associated with a stub of the given name
 # @param $1 name Name of the stub.
+# @param $2 key Key for the data value.
 _stub::data::prefix() {
-  local name=$($_stub_echo "$1" | $_stub_sed 's/:/_/g')
-  $_stub_echo "_stub_data_${name}"
+  local name="$1"
+  local key="$2"
+  if [ -n "$key" ]; then
+    $_stub_echo "{${name}}.$key"
+  else
+    $_stub_echo "{${name}}"
+  fi
 }
 
 # Sets data for a stub.
@@ -47,10 +55,15 @@ _stub::data::prefix() {
 _stub::data::set() {
   local name="$1"
   local key="$2"
-  local value="$3"
-  local prefix
-  prefix=$(_stub::data::prefix "$name")
-  eval "export ${prefix}_${key}='$value'"
+  local value="${@:3}"
+  local prefix=$(_stub::data::prefix "$name" "$key")
+  local line="${prefix}=$value"
+  if [ -n "$($_stub_grep "${prefix}" .stubdata)" ]; then
+    local replaced=$($_stub_sed "s/${prefix}=.*/$line/" .stubdata)
+    $_stub_echo "$replaced" > .stubdata
+  else
+    $_stub_echo "$line" >> .stubdata
+  fi
 }
 
 # Gets (echos) data for a stub.
@@ -59,9 +72,8 @@ _stub::data::set() {
 _stub::data::get() {
   local name="$1"
   local key="$2"
-  local prefix
-  prefix=$(_stub::data::prefix "$name")
-  eval "$_stub_echo \$${prefix}_${key}"
+  local prefix=$(_stub::data::prefix "$name" "$key")
+  $_stub_grep "$prefix" .stubdata | $_stub_cut -d '=' -f 2
 }
 
 # Deletes data for a stub.
@@ -70,27 +82,22 @@ _stub::data::get() {
 _stub::data::delete() {
   local name="$1"
   local key="$2"
-  local prefix
-  prefix=$(_stub::data::prefix "$name")
-  eval "unset ${prefix}_${key}"
+  local prefix=$(_stub::data::prefix "$name" "$key")
+  local results=$(sed -n "/^$prefix/!p" .stubdata)
+  $_stub_echo "$results" > .stubdata
 }
 
-# Deletes all environment data associated with a stub of the given name.
-# @param $1 name Name of the stub.
+# Deletes data associated with a stub of the given name. If a name is not passed
+# then this will clear all stub related data.
+# @param $1 [name] Optional name for the stub.
 _stub::data::clear() {
   local name="$1"
-  local prefix
-  prefix=$(_stub::data::prefix "$name")
-  local all_variables
-  all_variables=$(
-    $_stub_env | \
-      $_stub_grep "$prefix" | \
-      $_stub_sed 's/=/ /' | \
-      $_stub_awk '{print $1}'
-  )
-  for key in $all_variables; do
-    eval "unset ${key}"
-  done
+  if [ -n "$name" ]; then
+    local results=$(sed -n "/^{$name}/!p" .stubdata)
+    $_stub_echo "$results" > .stubdata
+  else
+    $_stub_echo '' > .stubdata
+  fi
 }
 
 # Resets counts, argument lists, etc. associated with a stub of the given name.
@@ -240,7 +247,7 @@ _stub::methods::errors() {
   local code
 
   # Handle the optional parameters
-  if [ $# -lt 2 ]; then
+  if [ $# -lt 3 ]; then
     output="$2"
     code=1
     if [ "$output" -eq "$output" ] 2> /dev/null; then

--- a/test/core.sh
+++ b/test/core.sh
@@ -22,56 +22,40 @@ describe '_stub'
     describe 'prefix'
       it 'should echo the correct stub data prefix'
         local name='some_stubbed_command'
-        local expected="_stub_data_${name}"
+        local expected="{${name}}"
         local result=$(_stub::data::prefix "$name")
         assert equal "$expected" "$result"
       end
 
-      it 'should replace colons with underscores'
-        local name='some::cmd'
-        local expected="_stub_data_some__cmd"
-        local result=$(_stub::data::prefix "$name")
-        assert equal "$expected" "$result"
+      it 'should echo the correct key value prefix'
+        local name='stubbed'
+        local key='keyname'
+        local expected="{${name}}.${key}"
+        assert equal "$expected" "$(_stub::data::prefix $name $key)"
       end
     end # prefix
 
     describe 'set'
-      it 'should set the given data in the environment'
-        local name='stub_name'
-        local key='variable_key'
-        local value='variable_value'
-        local prefix=$(_stub::data::prefix "$name")
-        _stub::data::set "$name" "$key" "$value"
-        local variable_name="${prefix}_${key}"
-        local result=$(eval "echo \$${variable_name}")
-        assert equal "$value" "$result"
-        eval "unset \$${variable_name}"
+      it 'should set the value for the given key'
+        echo '' > .stubdata
+        _stub::data::set 'name' 'key' 'value'
+        local was_set=$(grep '{name}.key=value' .stubdata | wc -l | sed 's/ //g')
+        assert equal "$was_set" "1"
       end
     end # set
 
     describe 'get'
       it 'should return the requested information'
-        local name='stub_name'
-        local key='some_key'
-        local value='wowza'
-        _stub::data::set "$name" "$key" "$value"
-        local result=$(_stub::data::get "$name" "$key")
-        assert equal "$value" "$result"
-        local variable_name="$(_stub::data::prefix "$name")_${key}"
-        eval "unset \$${variable_name}"
+        echo '{name}.key=1234' > .stubdata
+        assert equal "1234" "$(_stub::data::get 'name' 'key')"
       end
     end # get
 
     describe 'delete'
       it 'should delete the given key from the environment'
-        local name='madbeatz'
-        local key='rappers'
-        local value='coolio'
-        local prefix=$(_stub::data::prefix "$name")
-        _stub::data::set "$name" "$key" "$value"
-        _stub::data::delete "$name" "$key"
-        local result=$(_stub::data::get "$name" "$key")
-        assert equal '' "$result"
+        echo '{name}.key=alpha' > .stubdata
+        _stub::data::delete 'name' 'key'
+        assert equal '' "$(_stub::data::get 'name' 'key')"
       end
     end # delete
 
@@ -112,12 +96,7 @@ describe '_stub'
       end
 
       # after
-        _stub::data::delete "$name" 'call_count'
-        _stub::data::delete "$name" 'last_args'
-        _stub::data::delete "$name" 'default_stdout'
-        _stub::data::delete "$name" 'default_stderr'
-        _stub::data::delete "$name" 'default_command'
-        _stub::data::delete "$name" 'default_status_code'
+        _stub::data::clear "$name"
       #
     end # init
 
@@ -143,31 +122,22 @@ describe '_stub'
 
     describe 'clear'
       it 'should remove all variables associated with a stub'
-        local name='stub_name'
-        local prefix=$(_stub::data::prefix "$name")
-        eval "
-          export ${prefix}_a=10
-          export ${prefix}_b=20
-          export ${prefix}_c=30
-        "
-        _stub::data::clear "$name"
-        local a_val=$(_stub::data::get "$name" 'a')
-        local b_val=$(_stub::data::get "$name" 'b')
-        local c_val=$(_stub::data::get "$name" 'c')
-        [ -z "$a_val" ] && [ -z "$b_val" ] && [ -z "$c_val" ]
-        assert equal $? 0
+        echo '{name}.alpha=1' > .stubdata
+        echo '{name}.beta=2' >> .stubdata
+        echo '{other}.wow=neat' >> .stubdata
+        echo '{name}.gamma=3' >> .stubdata
+        echo '{name}.delta=4' >> .stubdata
+        _stub::data::clear 'name'
+        local expected='{other}.wow=neat'
+        assert equal "$expected" "$(cat .stubdata)"
       end
 
-      it 'should not delete variables not associated with a stub'
-        local name='stub_namezzz_yo'
-        local prefix=$(_stub::data::prefix "$name")
-        export _not_a_thing_yo=40
-        _stub::data::set "$name" "a" 12304
-        _stub::data::clear "$name"
-        local a_val=$(_stub::data::get "$name" 'a')
-        [ -z "$a_val" ] && [ -n "$_not_a_thing_yo" ]
-        assert equal $? 0
-        unset _not_a_thing_yo
+      it 'should clear all data when not given a name'
+        echo 'aaa' > .stubdata
+        echo 'aaa' >> .stubdata
+        echo 'aaa' >> .stubdata
+        _stub::data::clear
+        assert equal '' "$(cat .stubdata)"
       end
     end # clear
   end # data

--- a/test/core.sh
+++ b/test/core.sh
@@ -26,6 +26,13 @@ describe '_stub'
         local result=$(_stub::data::prefix "$name")
         assert equal "$expected" "$result"
       end
+
+      it 'should replace colons with underscores'
+        local name='some::cmd'
+        local expected="_stub_data_some__cmd"
+        local result=$(_stub::data::prefix "$name")
+        assert equal "$expected" "$result"
+      end
     end # prefix
 
     describe 'set'


### PR DESCRIPTION
This fixes the following:
- Allows for `:` in stub names
- No longer use the shell environment for storing stub variables (uses a local `.stubdata` file)

Reviewers:
- [x] @anandkumarpatel 
