### PR TITLE
Fixes for get and set

### DIFF
--- a/shtub.sh
+++ b/shtub.sh
@@ -74,7 +74,7 @@ _stub::data::get() {
   local name="$1"
   local key="$2"
   local prefix=$(_stub::data::prefix "$name" "$key")
-  $_stub_grep "$prefix" .stubdata | $_stub_cut -d '=' -f 2
+  $_stub_grep "$prefix=" .stubdata | $_stub_cut -d '=' -f 2
 }
 
 # Deletes data for a stub.

--- a/shtub.sh
+++ b/shtub.sh
@@ -30,6 +30,7 @@ _stub_awk="$(which awk)"
 _stub_env=$(which env)
 _stub_cat=$(which cat)
 _stub_cut=$(which cut)
+_stub_touch=$(which touch)
 
 ################################################################################
 # Core Methods
@@ -57,13 +58,13 @@ _stub::data::set() {
   local key="$2"
   local value="${@:3}"
   local prefix=$(_stub::data::prefix "$name" "$key")
-  local line="${prefix}=$value"
+
+  $_stub_touch .stubdata
   if [ -n "$($_stub_grep "${prefix}" .stubdata)" ]; then
-    local replaced=$($_stub_sed "s/${prefix}=.*/$line/" .stubdata)
-    $_stub_echo "$replaced" > .stubdata
-  else
-    $_stub_echo "$line" >> .stubdata
+    local results=$(sed -n "/^$prefix/!p" .stubdata)
+    $_stub_echo "$results" > .stubdata
   fi
+  $_stub_echo "${prefix}=$value" >> .stubdata
 }
 
 # Gets (echos) data for a stub.
@@ -192,7 +193,7 @@ _stub::exec() {
   if [ -n "$default_command" ]; then
     ${default_command} ${argv}
     return $?
-  elif (( $default_status_code > 0 )); then
+  elif [ "$default_status_code" -gt "0" ]; then
     if [ -n "$default_stderr" ]; then
       $_stub_echo "$default_stderr" >&2
     fi

--- a/test/core.sh
+++ b/test/core.sh
@@ -42,6 +42,14 @@ describe '_stub'
         local was_set=$(grep '{name}.key=value' .stubdata | wc -l | sed 's/ //g')
         assert equal "$was_set" "1"
       end
+
+      it 'should allow slashes in the value'
+        echo '' > .stubdata
+        _stub::data::set 'name' 'key' 'initial'
+        _stub::data::set 'name' 'key' '/this/path/should/work'
+        local was_set=$(grep '/this/path/should/work' .stubdata | wc -l | sed 's/ //g')
+        assert equal "$was_set" "1"
+      end
     end # set
 
     describe 'get'


### PR DESCRIPTION
Get and set still had a couple of kinks to work out, this fixes:
- `data::set` was depending on sed to perform the replacement, removed this requirement since it would require weird escaping. Now just simply omitting the entire key and appending it on the end.
- `data::get` was not matching on the full key, simply had to add the `=` in to get it to correctly match (was breaking `on_call 10` which would match the first call).
- [x] @anandkumarpatel 
